### PR TITLE
Use JIRA task ID as a tag, if present

### DIFF
--- a/on_modify.py
+++ b/on_modify.py
@@ -47,6 +47,9 @@ def extract_tags_from(json_obj):
     # Extract attributes for use as tags.
     tags = [json_obj['description']]
 
+    if 'jiraid' in json_obj:
+        tags.append(json_obj['jiraid'])
+
     if 'project' in json_obj:
         tags.append(json_obj['project'])
 


### PR DESCRIPTION
If the task was imported from JIRA using bugwarrior, use the JIRA task ID as an additional tag.