### PR TITLE
Use last annotation as additional tag, if present

### DIFF
--- a/on_modify.py
+++ b/on_modify.py
@@ -53,6 +53,9 @@ def extract_tags_from(json_obj):
     if 'tags' in json_obj:
         tags.extend(json_obj['tags'])
 
+    if 'annotations' in json_obj:
+        tags.append(json_obj['annotations'][-1]['description'])
+
     return tags
 
 


### PR DESCRIPTION
From @fdcds:
This allows the following workflow to be effective and tracked in a useful manner:
```
task 123 start First draft
task 123 stop
...
task 123 start Second iteration
task 123 stop
...
task 123 start Bugfixing
task 123 stop
...
```

This will be tracked as:
```
01:00 - 02:00 <TASK 123 TAGS> "First draft"
03:00 - 04:00 <TASK 123 TAGS> "Second iteration"
05:00 - 06:00 <TASK 123 TAGS> "Bugfixing"
```