### PR TITLE
Fix taskwarrior hook when tags are numeric values

### DIFF
--- a/on_modify.py
+++ b/on_modify.py
@@ -51,6 +51,9 @@ def extract_tags_from(json_obj):
         tags.append(json_obj['project'])
 
     if 'tags' in json_obj:
+        for i in range(len(json_obj['tags'])):
+            if json_obj['tags'][i].isnumeric():
+                json_obj['tags'][i] = '#' + json_obj['tags'][i]
         tags.extend(json_obj['tags'])
 
     return tags


### PR DESCRIPTION
When tags are numeric (ex: `3148`) the hook fails, because timewarrior treats it as a time value.

The above change prepends `#` to all numeric tags, so that timewarrior will be triggered by taskwarrior correctly when using numeric only tags (for example: issue ids automatically fetched with bugwarrior).