### PR TITLE
Let on-modify.timewarrior rename older intervals too

### DIFF
--- a/on_modify.py
+++ b/on_modify.py
@@ -29,6 +29,7 @@
 import json
 import subprocess
 import sys
+import shlex
 
 # Hook should extract all the following for use as Timewarrior tags:
 #   UUID
@@ -82,19 +83,21 @@ def main(old, new):
         subprocess.call(['timew', start_or_stop] + tags + [':yes'])
 
     # Modifications to task other than start/stop
-    elif 'start' in new and 'start' in old:
-        old_tags = extract_tags_from(old)
-        new_tags = extract_tags_from(new)
+    old_tags = extract_tags_from(old)
+    new_tags = extract_tags_from(new)
 
-        if old_tags != new_tags:
-            subprocess.call(['timew', 'untag', '@1'] + old_tags + [':yes'])
-            subprocess.call(['timew', 'tag', '@1'] + new_tags + [':yes'])
+    if old_tags != new_tags:
+        ids = subprocess.check_output(['timew', 'get', 'dom.tracked.ids', old['description']], stderr=subprocess.STDOUT).decode()
+        ids = shlex.split(ids)
 
-        old_annotation = extract_annotation_from(old)
-        new_annotation = extract_annotation_from(new)
+        subprocess.call(['timew', 'untag'] + ids + old_tags + [':yes'])
+        subprocess.call(['timew', 'tag'] + ids + new_tags + [':yes'])
 
-        if old_annotation != new_annotation:
-            subprocess.call(['timew', 'annotate', '@1', new_annotation])
+    old_annotation = extract_annotation_from(old)
+    new_annotation = extract_annotation_from(new)
+
+    if old_annotation != new_annotation:
+        subprocess.call(['timew', 'annotate', '@1', new_annotation])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
From @sskras:

Until now the hook renamed only the current interval, the @1 upon renaming the task.  With this change it tries to find all existing intervals with the same Description and rename them all.

Relates to [#338](https://github.com/GothenburgBitFactory/timewarrior/issues/338)

Signed-off-by: Saulius Krasuckas <saulius2@ar-fi.lt>