### PR TITLE
prevent tags from being separated inbetween

### DIFF
--- a/on_modify.py
+++ b/on_modify.py
@@ -51,7 +51,7 @@ def extract_tags_from(json_obj):
         tags.append(json_obj['project'])
 
     if 'tags' in json_obj:
-        tags.extend(json_obj['tags'])
+        tags.extend([json_obj['tags']])
 
     return tags
 

--- a/on_modify.py
+++ b/on_modify.py
@@ -51,7 +51,13 @@ def extract_tags_from(json_obj):
         tags.append(json_obj['project'])
 
     if 'tags' in json_obj:
-        tags.extend([json_obj['tags']])
+        if type(json_obj['tags']) is str:
+            # Usage of tasklib (e.g. in taskpirate) converts the tag list into a string
+            # If this is the case, convert it back into a list first
+            # See https://github.com/tbabej/taskpirate/issues/11
+            tags.extend(json_obj['tags'].split(','))
+        else:
+            tags.extend(json_obj['tags'])
 
     return tags
 

--- a/test/test_on-modify_unit.py
+++ b/test/test_on-modify_unit.py
@@ -367,3 +367,62 @@ def test_hook_should_process_stop():
     )
 
     verify(subprocess).call(['timew', 'stop', 'Foo', ':yes'])
+
+@pytest.mark.usefixtures("teardown")
+def test_hook_should_process_start_issue34_with_multiple_tags():
+    """on-modify hook should process 'task start' (issue #34) with multiple tags"""
+
+    when(subprocess).call(...)
+    on_modify.main(
+        json.loads(
+            '''{
+            "description": "Foo",
+            "entry": "20190820T203842Z",
+            "modified": "20190820T203842Z",
+            "status": "pending",
+            "tags": ["abc", "xyz"],
+            "uuid": "16af44c5-57d2-43bf-97ed-cf2e541d927f"
+            }'''),
+        json.loads(
+            '''{
+            "description": "Foo",
+            "entry": "20190820T203842Z",
+            "modified": "20190820T203842Z",
+            "start": "20190820T203842Z",
+            "status": "pending",
+            "tags": "abc,xyz",
+            "uuid": "16af44c5-57d2-43bf-97ed-cf2e541d927f"
+            }''')
+    )
+
+    verify(subprocess).call(['timew', 'start', 'Foo', 'abc', 'xyz', ':yes'])
+
+
+@pytest.mark.usefixtures("teardown")
+def test_hook_should_process_start_issue34_with_single_tags():
+    """on-modify hook should process 'task start' (issue #34) with single tags"""
+
+    when(subprocess).call(...)
+    on_modify.main(
+        json.loads(
+            '''{
+            "description": "Foo",
+            "entry": "20190820T203842Z",
+            "modified": "20190820T203842Z",
+            "status": "pending",
+            "tags": ["abc"],
+            "uuid": "16af44c5-57d2-43bf-97ed-cf2e541d927f"
+            }'''),
+        json.loads(
+            '''{
+            "description": "Foo",
+            "entry": "20190820T203842Z",
+            "modified": "20190820T203842Z",
+            "start": "20190820T203842Z",
+            "status": "pending",
+            "tags": "abc",
+            "uuid": "16af44c5-57d2-43bf-97ed-cf2e541d927f"
+            }''')
+    )
+
+    verify(subprocess).call(['timew', 'start', 'Foo', 'abc', ':yes'])


### PR DESCRIPTION
I experienced that tags such as `+next` where separated as `+n e x t` and thus the time tracking integration was not properly working.
The PR just adds the brackets around the parsed output from task warrior and thus is able to iterate over the list as a whole and not over the independent characters.
