### PR TITLE
Improve E2E test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build ${{ matrix.name }}
+      - name: Build e2e on ${{ matrix.name }}
         env:
           REGISTRY: ghcr.io
           OWNER: ${{ env.REPOSITORY }}
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONTAINER: ${{ matrix.container }}
         run: docker compose build ${CONTAINER}
-      - name: Test ${{ matrix.name }}
+      - name: Run e2e on ${{ matrix.name }}
         env:
           REGISTRY: ghcr.io
           OWNER: ${{ env.REPOSITORY }}

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -57,6 +57,9 @@ RUN mkdir -p ~/.task/hooks
 RUN cp on_modify.py ~/.task/hooks/on-modify.timewarrior
 RUN chmod +x ~/.task/hooks/on-modify.timewarrior
 
+RUN echo "timew: $( timew --version )" ; \
+    echo "task: $( task --version )"
+
 # Run tests
 ENV TASK_USE_PATH=true TIMEW_USE_PATH=true
 CMD [ "bash", "-c", "/venv/bin/pytest /task-on-modify-hook/test/test_on-modify_e2e.py"]

--- a/test/docker/task-timew.dockerfile
+++ b/test/docker/task-timew.dockerfile
@@ -37,3 +37,7 @@ COPY --from=timew /usr/local/bin/timew /usr/local/bin
 # Initialize Timewarrior
 WORKDIR /root/
 RUN timew :yes
+
+# Print version information
+RUN echo "timew: $( timew --version )" ; \
+    echo "task: $( task --version )"


### PR DESCRIPTION
- Print versions of Timewarrior and Taskwarrior at the end of combined image build
  Clarify what 'develop'/'stable' means in this image
- Rename action stages
  Clarify that this builds and runs the e2e test Docker image